### PR TITLE
Update BitmapDataTextureLoader.hx

### DIFF
--- a/src/spine/openfl/BitmapDataTextureLoader.hx
+++ b/src/spine/openfl/BitmapDataTextureLoader.hx
@@ -40,6 +40,30 @@ class BitmapDataTextureLoader implements TextureLoader {
 			region.packedHeight = region.packedWidth;
 			region.packedWidth = v1;
 
+			#if !spine4
+			if(region.originalWidth == region.packedWidth && region.originalHeight == region.packedHeight || (region.width < region.packedWidth && region.height < region.packedHeight))
+			{
+				if(region.width < region.originalWidth)
+				{
+					region.packedWidth = region.width;
+				}
+				if(region.height < region.originalHeight)
+				{
+					region.packedHeight = region.height;
+				}
+			}
+			else
+			{
+				if(region.height < region.originalWidth)
+				{
+					region.packedWidth = region.height;
+				}
+				if(region.width < region.originalHeight)
+				{
+					region.packedHeight = region.width;
+				}
+			}
+			#end
 		}
 	}
 

--- a/src/spine/openfl/BitmapDataTextureLoader.hx
+++ b/src/spine/openfl/BitmapDataTextureLoader.hx
@@ -41,29 +41,6 @@ class BitmapDataTextureLoader implements TextureLoader {
 			region.packedWidth = v1;
 
 		}
-
-		if(region.originalWidth == region.packedWidth && region.originalHeight == region.packedHeight || (region.width < region.packedWidth && region.height < region.packedHeight))
-		{
-			if(region.width < region.originalWidth)
-			{
-				region.packedWidth = region.width;
-			}
-			if(region.height < region.originalHeight)
-			{
-				region.packedHeight = region.height;
-			}
-		}
-		else
-		{
-			if(region.height < region.originalWidth)
-			{
-				region.packedWidth = region.height;
-			}
-			if(region.width < region.originalHeight)
-			{
-				region.packedHeight = region.width;
-			}
-		}
 	}
 
 	public function unloadPage (page:AtlasPage):Void {


### PR DESCRIPTION
The removed part was compensating a problem with the runtime spine-hx in reading atlas data

https://github.com/jeremyfa/spine-hx/commit/941d2e350a09332ec1bdf831f7881f9993c08a9e

Now that spine-hx has been fixed these lines must be removed.