### PR TITLE
clipping issue

### DIFF
--- a/src/spine/openfl/SkeletonSprite.hx
+++ b/src/spine/openfl/SkeletonSprite.hx
@@ -590,6 +590,10 @@ class SkeletonSprite extends #if !zygame Sprite #else DisplayObjectContainer #en
 				}
 				clipper.clipEndWithSlot(slot);
 			}
+			else if (slot != null && clipper.isClipping())
+			{
+				clipper.clipEndWithSlot(slot);
+			}
 		}
 
 		// 最后一个，直接渲染


### PR DESCRIPTION
Clipping must be stopped even when the EndSlot does not contain any attachment otherwise we mask untill the end of the display list.